### PR TITLE
ci: fix missing workflow permissions alert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes missing workflow permissions by explicitly setting `permissions: contents: read` in the CI workflow, as recommended by CodeQL to limit GITHUB_TOKEN scope and enforce the principle of least privilege. Resolves CodeQL alerts #1 and #2.