### PR TITLE
fix: upgrade Gemini models to the 3.x stable line

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 EMBEDDING_DIMENSIONS=768
 EMBEDDING_MODEL=gemini-embedding-001
-GEMINI_MODEL=gemini-2.5-flash
+GEMINI_MODEL=gemini-3.7-flash
 GOOGLE_API_KEY=your_api_key_here
 RAG_DB_PATH=/tmp/rag_demo.db

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ You can deploy the live, dynamic version to Google [Cloud Run](https://cloud.goo
     export GOOGLE_CLOUD_PROJECT=your-project-id
     export REGION=us-central1
     export GOOGLE_CLOUD_LOCATION=global
-    export GEMINI_MODEL=gemini-3-flash-preview
+    export GEMINI_MODEL=gemini-3.7-flash
     export EMBEDDING_MODEL=gemini-embedding-001
     export RAG_DB_PATH=/tmp/rag_demo.db
     export FORWARDED_ALLOW_IPS="*"  # Use specific IP addresses for better security

--- a/patterns/config.py
+++ b/patterns/config.py
@@ -3,4 +3,4 @@
 import os
 
 # Default model to use for agents
-GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
+GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-3.7-flash")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 [tool.pyrefly]
 
 [tool.pytest.ini_options]
-env = ["GEMINI_MODEL=gemini-2.5-flash-lite"]
+env = ["GEMINI_MODEL=gemini-3.5-flash-lite"]
 filterwarnings = [
     "ignore::DeprecationWarning:google.adk.*",
     "ignore::DeprecationWarning:google.genai.*",


### PR DESCRIPTION
## What

Moves the model defaults onto the 3.x stable line and refreshes the CI cost pin.

### The documented and actual defaults disagreed

`patterns/config.py` defaulted to `gemini-2.5-flash`, while the deployment section of the README told readers to `export GEMINI_MODEL=gemini-3-flash-preview`. Neither was current. Both now use `gemini-3.7-flash`, along with `.env.example`.

### CI test pin

`pyproject.toml` already pinned tests a tier down for cost via `pytest-env` — but at `gemini-2.5-flash-lite`, which is outdated. It now points at `gemini-3.5-flash-lite`.

This matters because the suite makes **real API calls**: the tests drive live ADK agents through `InMemoryRunner` against a real `GEMINI_API_KEY` in CI. Only the RAG embeddings are mocked.

Worth noting the pin has to live in `pyproject.toml` rather than the workflow — `pytest-env` overrides process environment, so a `GEMINI_MODEL` entry in `ci.yml` would silently do nothing.

## Verification

- Full suite against the real API: **26 passed**.
- One run hit a transient `503 UNAVAILABLE` on the HITL test. Re-running it on **unmodified `main`** reproduced the same failure, then both passed — a service blip, not this change.
- `gemini-3.7-flash` and `gemini-3.5-flash-lite` both confirmed live (HTTP 200).

## Notes

`deploy-pages.yml` is unchanged on purpose. `build.py` generates static JSON mocks and makes no Gemini calls, so the `GOOGLE_API_KEY` passed to that step isn't used for inference and there is no cost to pin.
